### PR TITLE
[users] User avatar is gone when just submit form without any uploads

### DIFF
--- a/html/modules/user/actions/AvatarEditAction.class.php
+++ b/html/modules/user/actions/AvatarEditAction.class.php
@@ -244,7 +244,7 @@ class User_AvatarEditAction extends User_AbstractEditAction
 	
 		$this->_resize();
 		
-		if ($this->mActionForm->mOldAvatarFilename != null && $this->mActionForm->mOldAvatarFilename != "blank.gif") {
+		if ($this->mActionForm->mOldAvatarFilename != null && $this->mActionForm->mOldAvatarFilename != "blank.gif" and $this->mActionForm->mFormFile != null) {
 			$avatarHandler =& xoops_getmodulehandler('avatar', 'user');
 			$criteria =new Criteria('avatar_file', $this->mActionForm->mOldAvatarFilename);
 			$avatarArr =& $avatarHandler->getObjects($criteria);
@@ -269,7 +269,7 @@ class User_AvatarEditAction extends User_AbstractEditAction
 				
 				$linkHandler->insert($link);
 			}
-			
+
 			return true;
 		}
 		else {


### PR DESCRIPTION
# Reproduction steps
- Login with `admin`
- Go to user module preference
- Check "Yes"  for "Allow custom avatar upload?" and submit
- Go to "Edit avatar" and upload a image and submit
- Again go to "Edit avatar"  and just click "Submit" to submit (don't upload any images here)
# Expected Result

Uploaded avatar appears in user information page.
# Actual Result

Uploaded avatar is gone in user information page.

![](https://dl.dropbox.com/u/949822/github.com/suin-legacy-issue-15-actual-result.png)
