### PR TITLE
Add delegate point after user activation done

### DIFF
--- a/html/modules/user/actions/UserActivateAction.class.php
+++ b/html/modules/user/actions/UserActivateAction.class.php
@@ -67,11 +67,13 @@ class User_UserActivateAction extends User_AbstractEditAction
 			$director->contruct();
 			$mailer=&$builder->getResult();
 			if ($mailer->send()) {
+				XCube_DelegateUtils::call('Legacy.Event.UserActivate.Success', $this->mObject, $this->mConfig);
 				$controller->executeRedirect(XOOPS_URL . '/', 5, sprintf(_MD_USER_MESSAGE_ACTVMAILOK, $this->mObject->get('uname')));
 			} else {
 				$controller->executeRedirect(XOOPS_URL . '/', 5, sprintf(_MD_USER_MESSAGE_ACTVMAILNG, $this->mObject->get('uname')));
 			}
 		} else {
+			XCube_DelegateUtils::call('Legacy.Event.UserActivate.Success', $this->mObject, $this->mConfig);
 			$controller->executeRedirect(XOOPS_URL . '/user.php', 5, _MD_USER_MESSAGE_ACTLOGIN);
 		}
 	}


### PR DESCRIPTION
I need a delegate point after user activation done.

I suggest the name is `Legacy.Event.UserActivate.Success`.

And callback interface is like this:

```
function(UserUsersObject $user, array $config) {}
```

This delegate point will be useful for changing behavior after activation like `Legacy.Event.CheckLogin.Success`.

For example,
- Auto logging in after activation
- Tracking user conversions with affiliate program
- Change redirection massage

Auto logging in after activation example:

``` php

<?php

class Example extends XCube_ActionFilter
{
    public function preFilter()
    {
        $delegateManager = $this->mRoot->mDelegateManager;
        $delegateManager->add('Legacy.Event.UserActivate.Success', function(UserUsersObject $user, array $config) {
            if ( $config['activation_type'] == 0 ) {
                //
                // authorize here
                //
                $this->mRoot->mController->executeRedirect(XOOPS_URL, 3, "Logging in...");
            }
        });
    }
}
```
