### PR TITLE
Fix doc comment of XCube_DelegateUtils::call()

### DIFF
--- a/html/core/XCube_Delegate.class.php
+++ b/html/core/XCube_Delegate.class.php
@@ -534,9 +534,6 @@ class XCube_DelegateUtils
 	{
 	}
 
-    /**
-     * @deprecated raiseEvent()
-     */
     static function call()
     {
         $args = func_get_args();
@@ -560,6 +557,7 @@ class XCube_DelegateUtils
     }
 
     /**
+     * @deprecated Use call()
      * @public
      * @brief [Static] Utility method for calling event-delegates.
      * 


### PR DESCRIPTION
`XCube_DelegateUtils::call()` is annotated as `@deprecated`. This is invalid annotation. The actual deprecated function is `XCube_DelegateUtils::raiseEvent()`.
