### PR TITLE
fix xoops_gethandler() for internal class in cube_legacy 2.2.1

### DIFF
--- a/html/include/functions.php
+++ b/html/include/functions.php
@@ -579,8 +579,13 @@ function &xoops_gethandler($name, $optional = false )
         XCube_DelegateUtils::call('Legacy.Event.GetHandler', new XCube_Ref($handler), $name, $optional);
         if ($handler) return $handlers[$name] =& $handler;
 
-        require_once XOOPS_ROOT_PATH.'/kernel/'.$name.'.php';
+	// internal Class handler exist
         if (XC_CLASS_EXISTS($class = 'Xoops'.ucfirst($name).'Handler')) {
+	    $handlers[$name] = $handler = new $class($GLOBALS['xoopsDB']);
+	    return $handler;
+        }
+	include_once XOOPS_ROOT_PATH.'/kernel/'.$name.'.php';
+	if (XC_CLASS_EXISTS($class)) {
 	    $handlers[$name] = $handler = new $class($GLOBALS['xoopsDB']);
 	    return $handler;
 		}


### PR DESCRIPTION
I miss with revised code for speed ups. This patch collect for that.

There is 2 points of collect work.
1. When internal hander class exists return it.
2. use 'include_once' because not critical error occasion when not exist file.

So this will be back compatible work with cube_legacy 2.2.0
