### PR TITLE
XoopsX/legacy  issue/32

### DIFF
--- a/html/core/XCube_RenderSystem.class.php
+++ b/html/core/XCube_RenderSystem.class.php
@@ -111,7 +111,7 @@ class XCube_RenderTarget
 	 */
 	function getType()
 	{
-		return $this->getAttribute('legacy_buffertype', $type);
+		return $this->getAttribute('legacy_buffertype');
 		//return $this->mType;
 	}
 	


### PR DESCRIPTION
@suin さんからの指摘分です。
XoopsX/legacy には適用済みです。

https://github.com/XoopsX/legacy/issues/32

到達不能の変数を削除
