### PR TITLE
permit break in delegate call chain

### DIFF
--- a/html/core/XCube_Delegate.class.php
+++ b/html/core/XCube_Delegate.class.php
@@ -75,6 +75,8 @@ define("XCUBE_DELEGATE_PRIORITY_FIRST", XCUBE_DELEGATE_PRIORITY_1);
 define("XCUBE_DELEGATE_PRIORITY_NORMAL", XCUBE_DELEGATE_PRIORITY_5);
 define("XCUBE_DELEGATE_PRIORITY_FINAL", XCUBE_DELEGATE_PRIORITY_10);
 
+define("XCUBE_DELEGATE_CHAIN_BREAK", -1);
+
 /**
  * @public
  * @brief [Final] Used for the simple mechanism for common delegation in XCube.
@@ -321,7 +323,9 @@ class XCube_Delegate
                 list($callback, $file) = $callback_array;
 
                	if ($file) require_once $file;
-               	if (is_callable($callback)) call_user_func_array($callback, $args);
+               	if (is_callable($callback)) {
+               		if (call_user_func_array($callback, $args) === XCUBE_DELEGATE_CHAIN_BREAK) break 2;
+               	}
             }
 		}
 	}


### PR DESCRIPTION
delegate call
の実行時に続きに登録された処理をキャンセルできるようにする試みです。

delegate への登録時に reset()
するのではなく実行時に続く処理をキャンセルできるようにすることで、実行時のパラメタから判断して、自己処理するか他に積まれたタスクにするかを選択できるようになります。

具体的には、'Site.TextareaEditor.BBCode.Show'
において、与えられたクラス名から判断して、自己処理するかもしくは、登録済みの規定の動作にするかに処理を分けたいと思っています。

実際の使用場面のコードは次のような感じです。

``` php
<?php
class HypCommonPreLoad extends XCube_ActionFilter {
    function postFilter() {
        $this->mRoot->mDelegateManager->add('Site.TextareaEditor.BBCode.Show',
array(&$this, 'BBCode_wiki_render'), XCUBE_DELEGATE_PRIORITY_FIRST);
    }

    function BBCode_wiki_render(&$html, $element) {
        if (preg_match('/(?:^| )(?:html|rich|wysiwyg)(?: |$)/',
$element['class'])) {
            return; // ここでは何もせず chain の続きを処理する
        } else {
            $element['class'] = trim(preg_replace('/ +/', '
', str_replace('bbcode', '', $element['class'])));
            $html = '<textarea name="'.$element['name'].'"
class="'.$element['class'].'" cols="'.$element['cols'].'"
rows="'.$element['rows'].'"
id="'.$element['id'].'">'.$element['value'].'</textarea>';
            // このあとの chain はキャンセルして 'Site.TextareaEditor.BBCode.Show' デリゲートを終了する
            return XCUBE_DELEGATE_CHAIN_BREAK;
        }
    }
}
```
