### PR TITLE
Fix Bug #3492904 - Error Message after Profile edit

### DIFF
--- a/html/modules/profile/class/handler/Data.class.php
+++ b/html/modules/profile/class/handler/Data.class.php
@@ -81,7 +81,7 @@ class Profile_DataHandler extends XoopsObjectGenericHandler
 		if(count($obj->mDef)===0){
 			return true;
 		}
-		parent::insert($obj, $force = false);
+		return parent::insert($obj, $force = false);
 	}
 
 }


### PR DESCRIPTION
git-svn-id: https://xoopscube.svn.sourceforge.net/svnroot/xoopscube/Package_Legacy/trunk@1137 704cf05f-ae62-4b0e-a484-234ee0250e75

以前に修正したものが @16048d36374b91364dc48e8da55cbc28a65d83d7 のコミットにより戻ってしまっていました。
