### PR TITLE
[profile] date DATATYPE allow more wide range

### DIFF
--- a/html/modules/profile/class/FieldType.class.php
+++ b/html/modules/profile/class/FieldType.class.php
@@ -278,7 +278,7 @@ class Profile_FieldTypeDate implements Profile_iFieldType
 
     public function getTableQuery()
     {
-        return 'INT(11) UNSIGNED NOT NULL';
+        return 'BIGINT(20) SIGNED';
     }
 
     public function setInitVar(/*** Profile_DataObject ***/ $obj, /*** string ***/ $key, /*** string ***/ $default)


### PR DESCRIPTION
日付型が 1970/1/1 より前と 2038/1/20 以降が扱えないので、扱える範囲を広めた。
