### PR TITLE
support the primary key has many fields

### DIFF
--- a/html/modules/legacy/kernel/handler.php
+++ b/html/modules/legacy/kernel/handler.php
@@ -50,14 +50,20 @@ class XoopsObjectGenericHandler extends XoopsObjectHandler
 	function &get($id)
 	{
 		$ret = null;
-		
-		$criteria =new Criteria($this->mPrimary, $id);
+		$i = 0;
+		if (is_array($id)){
+			$mPrimary = explode(",",$this->mPrimary);
+			$criteria = new CriteriaCompo();
+			foreach($mPrimary as $key){
+				$criteria->add(new Criteria($key,$id[$i]));
+			}
+		}else{
+			$criteria =new Criteria($this->mPrimary, $id);
+		}
 		$objArr =& $this->getObjects($criteria);
-		
 		if (count($objArr) == 1) {
 			$ret =& $objArr[0];
 		}
-
 		return $ret;
 	}
 


### PR DESCRIPTION
it can be use below style on the XoopsObjectGenericHandler class

```
public $mPrimary = 'uid,item_id';
```

and after that, it work at get method as 

$object = $handler->get( array($uid,$item_id) );

[ja]
XoopsObjectGenericHandler class でプライマリーキーに複数のフィールドを設定し、get関数でオブジェクトを取得出来る様にしました。
[ja]
