### PR TITLE
support editor delegate with xoopsform dhtmltarea

### DIFF
--- a/html/class/xoopsform/formdhtmltextarea.php
+++ b/html/class/xoopsform/formdhtmltextarea.php
@@ -71,7 +71,15 @@ class XoopsFormDhtmlTextArea extends XoopsFormTextArea
      * @access  private
      */
     private $_editor;
-
+    
+    /**
+     * Editor check for recursive prevention
+     * @static
+     * @var array
+     * @access  private
+     */
+    private static $_editorCheck = array();
+    
     /**
      * Constructor
      *
@@ -98,7 +106,8 @@ class XoopsFormDhtmlTextArea extends XoopsFormTextArea
 		$root =& XCube_Root::getSingleton();
 
 		$editor = $this->getEditor();
-		if ($editor) {
+		if ($editor && !isset(self::$_editorCheck[$id])) {
+			self::$_editorCheck[$id] = true;
 			$params['name'] = trim($this->getName(false));
 			$params['class'] = trim($this->getClass());
 			$params['cols'] = $this->getCols();


### PR DESCRIPTION
ex.

``` php
$tarea = new XoopsFormDhtmlTextArea('', 'body' , '') ;
if (method_exists($tarea, 'setEditor')) {
    $tarea->setEditor($allow_html? 'html' : 'bbcode');
}
```

[ja]
XCL 2.2 から採用された HTML エディタ仕様に対応した XoopsFormDhtmlTextArea です。
Smarty テンプレートを利用せず、XoopsForm オブジェクトを利用してレンダリングするフォームでも
HTML エディタの切り替えが可能になります。
[/ja]
