### PR TITLE
change xoopscube custom session.

### DIFF
--- a/html/core/XCube_Session.class.php
+++ b/html/core/XCube_Session.class.php
@@ -81,8 +81,14 @@ class XCube_Session
             // Refresh lifetime of Session Cookie
             $session_params = session_get_cookie_params();
             !$session_params['domain'] and $session_params['domain'] = null;
-            setcookie($this->mSessionName, session_id(), time() + $this->mSessionLifetime, $this->_cookiePath(), 
-                      $session_params['domain'], $session_params['secure'], $session_params['httponly']);
+            $session_cookie_params = array(
+                $this->mSessionName, session_id(), time() + $this->mSessionLifetime, $this->_cookiePath(), 
+                $session_params['domain'], $session_params['secure']
+                );
+            if (isset($session_params['httponly'])){
+                $session_cookie_params[] = $session_params['httponly'];
+            }
+            call_user_func_array('setcookie', $session_cookie_params);
         }
     }
 


### PR DESCRIPTION
 Enabled session.cookie_httponly/session.cookie_secure settings at php.ini.
[ja]
XOOPSのカスタムセッション（セッションCOOKIE名と有効時間の変更）をイキにしていた場合、php.iniなどで、session.cookie_httponly, session.cookie_secureをOnにしていてもこれらはOFFにされてしまう。
この変更ではこの2つの値がそのまま生かされるようにした。
[/ja]
