### PR TITLE
databaseに接続できない場合にメンテ案内文を表示

### DIFF
--- a/html/class/database/databasefactory.php
+++ b/html/class/database/databasefactory.php
@@ -1,17 +1,16 @@
 <?php
 class XoopsDatabaseFactory
 {
-
     public function XoopsDatabaseFactory()
     {
     }
 
     /**
      * Get a reference to the only instance of database class and connects to DB
-     * 
-     * if the class has not been instantiated yet, this will also take 
+     *
+     * if the class has not been instantiated yet, this will also take
      * care of that
-     * 
+     *
      * @static
      * @staticvar   object  The only instance of database class
      * @return      object  Reference to the only instance of database class
@@ -34,6 +33,9 @@ class XoopsDatabaseFactory
             $instance->setLogger(XoopsLogger::instance());
             $instance->setPrefix(XOOPS_DB_PREFIX);
             if (!$instance->connect()) {
+                echo "現在サーバが混み合っているか、メンテナンス中です。<br>\n";
+                echo "ご迷惑をおかけいたしますが、しばらく時間を空けて再度アクセスしてください。<br>\n\n";
+                echo "<!-- Unable to connect to database. -->\n\n<script>console.log('Unable to connect to database');</script>";
                 trigger_error("Unable to connect to database", E_USER_ERROR);
             }
         }
@@ -43,7 +45,7 @@ class XoopsDatabaseFactory
     /**
      * Gets a reference to the only instance of database class. Currently
      * only being used within the installer.
-     * 
+     *
      * @static
      * @staticvar   object  The only instance of database class
      * @return      object  Reference to the only instance of database class

--- a/html/class/database/databasefactory.php
+++ b/html/class/database/databasefactory.php
@@ -33,9 +33,8 @@ class XoopsDatabaseFactory
             $instance->setLogger(XoopsLogger::instance());
             $instance->setPrefix(XOOPS_DB_PREFIX);
             if (!$instance->connect()) {
-                echo "現在サーバが混み合っているか、メンテナンス中です。<br>\n";
-                echo "ご迷惑をおかけいたしますが、しばらく時間を空けて再度アクセスしてください。<br>\n\n";
-                echo "<!-- Unable to connect to database. -->\n\n<script>console.log('Unable to connect to database');</script>";
+                echo "Service temporarily unavailable. (Unable to connect to the database)";
+                header('HTTP/1.1 503 Service Temporarily Unavailable');
                 trigger_error("Unable to connect to database", E_USER_ERROR);
             }
         }


### PR DESCRIPTION
現在のXoopsXはdatabaseに接続できない場合に真っ白な画面を表示しますが、これは利用者を困惑させるとともに開発者をも惑わせ、また運営側に問題が発生していること簡単に想定させますので申し訳程度のメンテ中文章を表示するようにしました。

開発者向けにソース内には原因であるdatabase接続エラーを伝えるメッセージを入れてあります。（php error logを見ればわかるのですが、このエラーは基本的にはxoops setup時によく起こる問題のためxoops/php初心者の方にもわかりやすくする配慮です。）



