### PR TITLE
fixed referring to an undeclared constant value

### DIFF
--- a/html/modules/user/kernel/LegacypageFunctions.class.php
+++ b/html/modules/user/kernel/LegacypageFunctions.class.php
@@ -268,7 +268,7 @@ class User_LegacypageFunctions
             $user->set('pass', User_Utils::encryptPassword($pass), true);
             if (!$handler->insert($user, true)) {
                 // set $passwordNeedsRehash
-                self::$passwordNeedsRehash = ture;
+                self::$passwordNeedsRehash = true;
             }
         }
 


### PR DESCRIPTION
I found a code that referring to an undeclared constant value which seems to a typo of "true".
If my guess is false, please reject this pull request.
Thank you.
