### PR TITLE
Fix snooy not working with proxy server

### DIFF
--- a/html/class/snoopy.php
+++ b/html/class/snoopy.php
@@ -909,7 +909,6 @@ class snoopy
 
         if (PHP_VERSION_ID > 50000) {
             if($this->scheme == 'http'){
-                $port = 80;
                 $host = "tcp://" . $host;
             }
 


### PR DESCRIPTION
If proxy server is set and proxy port is 8080, the request fails. Keep port number from snoopy settings.