### PR TITLE
mysqli error report backword compatible

### DIFF
--- a/html/class/database/mysqlidatabase.php
+++ b/html/class/database/mysqlidatabase.php
@@ -19,6 +19,8 @@ if (!defined('XOOPS_ROOT_PATH')) {
  */
 include_once XOOPS_ROOT_PATH.'/class/database/database.php';
 
+mysqli_report( MYSQLI_REPORT_ERROR ); // for backword compat
+
 class XoopsMysqliDatabase extends XoopsDatabase
 {
     /**


### PR DESCRIPTION
When SQL error rise exceptions in PHP 8.2.
So setting backword compatible mode.
