### PR TITLE
fix: Legacy_ModuleUpdater

### DIFF
--- a/html/modules/legacy/admin/class/Legacy_Updater.class.php
+++ b/html/modules/legacy/admin/class/Legacy_Updater.class.php
@@ -202,7 +202,6 @@ class Legacy_ModuleUpdater extends Legacy_ModulePhasedUpgrader
      */
     public function _recoverXoopsGroupPermission()
     {
-        $xoopsDB = null;
         $root =& XCube_Root::getSingleton();
         $db =& $root->mController->getDB();
 
@@ -227,7 +226,7 @@ class Legacy_ModuleUpdater extends Legacy_ModulePhasedUpgrader
         if (0 != count($gids)) {
             $sql = sprintf('DELETE FROM `%s` WHERE `gperm_groupid` IN (%s) AND `gperm_modid`=1',
                            $permTable, implode(',', $gids));
-            $result = $xoopsDB->query($sql);
+            $result = $db->query($sql);
             if (!$result) {
                 return false;
             }


### PR DESCRIPTION
Fixed the part where $xoopsDB was used instead of $db in Legacy_ModuleUpdater::_recoverXoopsGroupPermission().