### PR TITLE
feat: Allow callable to clickable replacement

### DIFF
--- a/html/modules/legacy/kernel/Legacy_TextFilter.class.php
+++ b/html/modules/legacy/kernel/Legacy_TextFilter.class.php
@@ -325,7 +325,16 @@ class Legacy_TextFilter extends XCube_TextFilter
             //
             $this->mMakeClickablePre->call(new XCube_Ref($this->mClickablePatterns), new XCube_Ref($this->mClickableReplacements));
         }
-        $text = preg_replace($this->mClickablePatterns, $this->mClickableReplacements, $text);
+        foreach ($this->mClickablePatterns as $arrayIndex => $pattern) {
+            $replacement = $this->mClickableReplacements[$arrayIndex];
+            
+            if (is_callable($replacement)) {
+                $text = preg_replace_callback($pattern, $replacement, $text);
+            }else {
+                $text = preg_replace($pattern, $replacement, $text);
+            }
+        }
+        
         return $text;
     }
 


### PR DESCRIPTION
After applying this change, you can use callable for clickable conversion table replacements.


# Example of Usage

This is an example of preloading that truncates the length of the text portion when making a URL clickable.

```
class Ryus_TextFilterClickable extends XCube_ActionFilter
{
    const SHORTEN_CLICKABLE_LENGTH = 80;
    public function preBlockFilter()
    {
        $this->mRoot->mDelegateManager->add(
            'Legacy_TextFilter.MakeClickableConvertTable',
            [&$this, 'hook'],
            XCUBE_DELEGATE_PRIORITY_3
        );
    }

    public function hook(&$patterns, &$replacements)
    {
        $http_pat = "(^|[^]_a-z0-9-=\"'\/])([a-z]+?):\/\/([-_.!~*'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)(?=[\s\x80-\xff]|$)";
        $patterns =
            [
                "/{$http_pat}/i",
                "/(^|[^]_a-z0-9-=\"'\/])www\.([a-z0-9\-]+)\.([^, \r\n\"\(\)'<>]+)(?=[\s\x80-\xff]|$)/i",
                "/(^|[^]_a-z0-9-=\"'\/])ftp\.([a-z0-9\-]+)\.([^, \r\n\"\(\)'<>]+)(?=[\s\x80-\xff]|$)/i",
                "/(^|[^]_a-z0-9-=\"'\/:\.])([a-z0-9\-_\.]+?)@([a-z0-9!#\$%&'\*\+\-\/=\?^_\`{\|}~\.]+)(?=[\s\x80-\xff]|$)/i",
            ];
        $replacements =
            [
               // callable
                function (array $matches) {
                    $urlText = xoops_substr($matches[2] . '://' . $matches[3], 0, self::SHORTEN_CLICKABLE_LENGTH);
                    return sprintf('%s<a href="%s://%s" target="_blank">%s</a>', $matches[1], $matches[2], $matches[3],
                        $urlText);

                },
                function (array $matches) {
                    $urlText = 'www.' . xoops_substr($matches[2] . '.' . $matches[3], 0, self::SHORTEN_CLICKABLE_LENGTH);
                    return sprintf('%s<a href="http://www.%s.%s" target="_blank">%s</a>', $matches[1], $matches[2],
                        $matches[3], $urlText);

                },

                "\\1<a href=\"ftp://ftp.\\2.\\3\" target=\"_blank\">ftp.\\2.\\3</a>",
                "\\1<a href=\"mailto:\\2@\\3\">\\2@\\3</a>"
            ];
    }
}
```
